### PR TITLE
Link to Google play

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Download
 </p>
 
 <p align="center">
-  <a href="https://play.google.com/store/apps/details?id=fly.worship.grub"><img src="http://switzerland.tasis.com/uploaded/images2/appstore_button_google.png" height="100" width="306"/></a>
+  <a href="https://play.google.com/store/apps/details?id=fly.speedmeter.grub"><img src="http://switzerland.tasis.com/uploaded/images2/appstore_button_google.png" height="100" width="306"/></a>
 </p>
 


### PR DESCRIPTION
I changed the link to Google play from https://play.google.com/store/apps/details?id=fly.worship.grub into https://play.google.com/store/apps/details?id=fly.speedmeter.grub