### PR TITLE
Calculate averages in floating point

### DIFF
--- a/app/src/main/java/fly/speedmeter/grub/Data.java
+++ b/app/src/main/java/fly/speedmeter/grub/Data.java
@@ -58,19 +58,19 @@ public class Data {
         if (time <= 0) {
             average = 0.0;
         } else {
-            average = (distanceM / (time / 1000)) * 3.6;
+            average = (distanceM / (time / 1000.0)) * 3.6;
         }
         return average;
     }
 
     public double getAverageSpeedMotion(){
-        double motionTime = time - timeStopped;
+        long motionTime = time - timeStopped;
         double average;
         String units;
         if (motionTime <= 0){
             average = 0.0;
         } else {
-            average = (distanceM / (motionTime / 1000)) * 3.6;
+            average = (distanceM / (motionTime / 1000.0)) * 3.6;
         }
         return average;
     }


### PR DESCRIPTION
Ensure that time is recorded as a long in milliseconds but
calculations use doubles so that we do not truncate to zero.
Fixes #33.